### PR TITLE
New @import build process

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "src/vendor"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,7 +113,7 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases for our component build workflow.
    */
-  grunt.registerTask('vendor', ['bower', 'copy:component_assets', 'copy:docs_assets']);
+  grunt.registerTask('vendor', ['copy:component_assets', 'copy:docs_assets']);
   grunt.registerTask('default', ['less:core', 'autoprefixer', 'copy:docs', 'topdoc']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-core",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "Base styling, including heading hierarchy, links, and some handy webfont mixins for Capital Framework.",
   "keywords": [
     "capital-framework",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "posttest": "forever stopall -s"
   },
   "devDependencies": {
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
-    "cf-grunt-config": "~0.3.1",
+    "cf-component-demo": "^1.0.0",
+    "cf-grunt-config": "^1.0.0",
     "forever": "^0.14.1",
     "glob": "~4.3.2",
     "grunt": "~0.4.4",

--- a/src/cf-core.less
+++ b/src/cf-core.less
@@ -4,8 +4,8 @@
    ========================================================================== */
 
 
-@import (less) "normalize.css";
-@import (less) "normalize-legacy-addon.css";
+@import (less) "../../normalize-css/normalize.css";
+@import (less) "../../normalize-legacy-addon/normalize-legacy-addon.css";
 @import (less) "cf-vars.less";
 @import (less) "cf-media-queries.less";
 @import (less) "cf-utilities.less";


### PR DESCRIPTION
This implements the changes discussed in https://github.com/cfpb/capital-framework/issues/151.
## Removals
- Grunt bower task
## Changes
- CSS import paths are now relative.
- `bowerrc` points to `src/vendor` (the now defunct Grunt task used to do this)
- Bumped to `1.0.0`
## Testing
- You can't. :neutral_face: There's a chicken vs. the egg scenario here. This project's dependencies now point to the 1.x.x version of other CF components. But those versions aren't in Bower/npm yet because their PRs are still pending. This is why Travis is failing.
- The `dev` branch was thoroughly tested prior to this PR and more testing will occur afterward. There will likely be some kinks to work out after this merge but that's okay -- semver will shield current projects from any bugs.
## Review
- @Scotchester 
- @anselmbradford 
