### PR TITLE
update the default text input border color

### DIFF
--- a/src/cf-vars.less
+++ b/src/cf-vars.less
@@ -75,7 +75,7 @@
 
 // input
 @input-bg:                      #fff;
-@input-border:                  darken(#895983, 15%);
+@input-border:                  #babbbd;
 @input-border-focus:            #c7336e;
 @input-placeholder:             grayscale(#c7336e);
 


### PR DESCRIPTION
No idea if this is needed or if we should just leave the funky non-cfpb colors. I've put in a PR for this same variable in `cf-themes-overrides.less` https://github.com/cfpb/capital-framework/pull/184
